### PR TITLE
Sortierung der Referer angepasst

### DIFF
--- a/pages/referer.php
+++ b/pages/referer.php
@@ -1,6 +1,6 @@
 <?php
 
-$list = rex_list::factory('SELECT referer, count from ' . rex::getTable('pagestats_referer') . ' ORDER BY count DESC');
+$list = rex_list::factory('SELECT referer, count from ' . rex::getTable('pagestats_referer') . ' ORDER BY count DESC, referer ASC');
 
 $list->setColumnLabel('referer', 'Referer');
 $list->setColumnLabel('count', 'Anzahl');


### PR DESCRIPTION
Wenn die Parameter der URLs in der Referer Liste erhalten bleiben sollen, dann ist es von Vorteil, wenn die Sortierung um die Referer erweitert wird. So gibt es einen besseren Überblick über die referenzierenden Domains.